### PR TITLE
Add a start time argument to predict calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea/

--- a/api/model.py
+++ b/api/model.py
@@ -85,7 +85,12 @@ class Predict(Resource):
             raise e
 
         #Getting the predicions
-        preds = self.mw.predict("/audio.wav", int(args['start_time']))
+        try:
+            preds = self.mw.predict("/audio.wav", int(args['start_time']))
+        except ValueError:
+            e = BadRequest()
+            e.data = {'status': 'error', 'message': 'Invalid start time: value outside audio clip'}
+            raise e
         
         #Aligning the predictions to the required API format
         label_preds = [{'label_id': p[0], 'label': p[1], 'probability': p[2]} for p in preds]

--- a/api/model.py
+++ b/api/model.py
@@ -39,7 +39,7 @@ predict_response = api.model('ModelPredictResponse', {
 audio_parser = api.parser()
 audio_parser.add_argument('audio', type=FileStorage, location='files', required=True,
                           help="signed 16-bit PCM WAV audio file")
-audio_parser.add_argument('start_time', type=float, default=0, help='The time (in seconds) in the audio file to run prediction at.')
+audio_parser.add_argument('start_time', type=float, default=0, help='The number of seconds into the audio file the prediction should start at.')
 
 
 @api.route('/predict')

--- a/api/model.py
+++ b/api/model.py
@@ -41,7 +41,7 @@ predict_response = api.model('ModelPredictResponse', {
 # set up parser for audio input data
 audio_parser = api.parser()
 audio_parser.add_argument('audio', type=FileStorage, location='files', required=True)
-audio_parser.add_argument('start_time', type=float, default=0, help='The time stamp in the audio file to run prediction at. Prediction will be run on the following 10 sec. If it\'s larger than audio\'s duration it will be ignored.')
+audio_parser.add_argument('start_time', type=int, default=0, help='The time (in seconds) in the audio file to run prediction at.')
 
 
 @api.route('/predict')
@@ -64,7 +64,7 @@ class Predict(Resource):
         
         if os.path.exists("/audio.mp3"):
             os.remove("/audio.mp3")
-
+        
         #If the file is an mp3 file
         #   Read into mp3.
         #   Convert mp3 into wav using ffmpeg.

--- a/api/model.py
+++ b/api/model.py
@@ -69,7 +69,7 @@ class Predict(Resource):
             e.data = {'status': 'error', 'message': 'Invalid file type/extension'}
             raise e
 
-        # Getting the predicions
+        # Getting the predictions
         try:
             preds = self.mw.predict("/audio.wav", args['start_time'])
         except ValueError:

--- a/api/model.py
+++ b/api/model.py
@@ -41,7 +41,7 @@ predict_response = api.model('ModelPredictResponse', {
 # set up parser for audio input data
 audio_parser = api.parser()
 audio_parser.add_argument('audio', type=FileStorage, location='files', required=True)
-audio_parser.add_argument('start_time', type=int, default=0, help='The time (in seconds) in the audio file to run prediction at.')
+audio_parser.add_argument('start_time', type=float, default=0, help='The time (in seconds) in the audio file to run prediction at.')
 
 
 @api.route('/predict')
@@ -86,7 +86,7 @@ class Predict(Resource):
 
         #Getting the predicions
         try:
-            preds = self.mw.predict("/audio.wav", int(args['start_time']))
+            preds = self.mw.predict("/audio.wav", args['start_time'])
         except ValueError:
             e = BadRequest()
             e.data = {'status': 'error', 'message': 'Invalid start time: value outside audio clip'}

--- a/api/model.py
+++ b/api/model.py
@@ -41,6 +41,7 @@ predict_response = api.model('ModelPredictResponse', {
 # set up parser for audio input data
 audio_parser = api.parser()
 audio_parser.add_argument('audio', type=FileStorage, location='files', required=True)
+audio_parser.add_argument('start_time', type=float, default=0, help='The time stamp in the audio file to run prediction at. Prediction will be run on the following 10 sec. If it\'s larger than audio\'s duration it will be ignored.')
 
 
 @api.route('/predict')
@@ -63,7 +64,7 @@ class Predict(Resource):
         
         if os.path.exists("/audio.mp3"):
             os.remove("/audio.mp3")
-        
+
         #If the file is an mp3 file
         #   Read into mp3.
         #   Convert mp3 into wav using ffmpeg.
@@ -84,7 +85,7 @@ class Predict(Resource):
             raise e
 
         #Getting the predicions
-        preds = self.mw.predict("/audio.wav")
+        preds = self.mw.predict("/audio.wav", int(args['start_time']))
         
         #Aligning the predictions to the required API format
         label_preds = [{'label_id': p[0], 'label': p[1], 'probability': p[2]} for p in preds]

--- a/core/backend.py
+++ b/core/backend.py
@@ -97,13 +97,13 @@ class ModelWrapper(object):
         Returns:
             embeddings = numpy array of shape (1,10,128), dtype=float32.
         """
-        ts_adjusted = int(time_stamp / vggish_params.EXAMPLE_HOP_SECONDS)
+        embeddings_ts = int(time_stamp / vggish_params.EXAMPLE_HOP_SECONDS)
         embeddings_len = embeddings.shape[0]
-        if 0 < ts_adjusted < embeddings_len:
-            end_ts = ts_adjusted + 10
+        if 0 < embeddings_ts < embeddings_len:
+            end_ts = embeddings_ts + 10
             end_ts = end_ts if end_ts < embeddings_len else embeddings_len
-            embeddings = embeddings[ts_adjusted:end_ts,:]
-        elif ts_adjusted < 0 or ts_adjusted >= embeddings_len:
+            embeddings = embeddings[embeddings_ts:end_ts,:]
+        elif embeddings_ts < 0 or embeddings_ts >= embeddings_len:
             raise ValueError
 
         l = embeddings.shape[0]

--- a/core/backend.py
+++ b/core/backend.py
@@ -97,11 +97,11 @@ class ModelWrapper(object):
         Returns:
             embeddings = numpy array of shape (1,10,128), dtype=float32.
         """
-        ts_adjusted = time_stamp / vggish_params.EXAMPLE_HOP_SECONDS
+        ts_adjusted = int(time_stamp / vggish_params.EXAMPLE_HOP_SECONDS)
         embeddings_len = embeddings.shape[0]
         if 0 < ts_adjusted < embeddings_len:
             end_ts = ts_adjusted + 10
-            end_ts = end_ts if end_ts < embeddings_len else embeddings_len - 1
+            end_ts = end_ts if end_ts < embeddings_len else embeddings_len
             embeddings = embeddings[ts_adjusted:end_ts,:]
         elif ts_adjusted < 0 or ts_adjusted >= embeddings_len:
             raise ValueError

--- a/core/backend.py
+++ b/core/backend.py
@@ -64,7 +64,7 @@ class ModelWrapper(object):
         class_scores = output_tensor.eval(feed_dict={input_tensor: processed_embeddings}, session=self.session_classify)
         return class_scores
     
-    def predict(self, wav_file):
+    def predict(self, wav_file, time_stamp):
         """
         Driver function that performs all core tasks.
         Input args:
@@ -75,7 +75,7 @@ class ModelWrapper(object):
         #Step1: Generate the embeddings.
         raw_embeddings = self.generate_embeddings(wav_file)
         #Step2: Process the embeddings before sending it to the classifier.
-        embeddings_processed = self.classifier_pre_process(raw_embeddings)
+        embeddings_processed = self.classifier_pre_process(raw_embeddings, time_stamp)
         #Step3: Classify the embeddings.
         raw_preds = self.classify_embeddings(embeddings_processed)
         #Step4: Post process the raw prediction vectors to a more interpretable format.
@@ -83,7 +83,7 @@ class ModelWrapper(object):
         return preds
 
         
-    def classifier_pre_process(self, embeddings):
+    def classifier_pre_process(self, embeddings, time_stamp):
         """
         Helper function to make sure input to classifier the model is of standard size.
         * Augments audio embeddings shorter than 10 seconds (10x128 tensor) to a multiple of itself 
@@ -96,6 +96,9 @@ class ModelWrapper(object):
         Returns:
             embeddings = numpy array of shape (1,10,128), dtype=float32.
         """
+        if 0 < time_stamp < embeddings.shape[0]:
+            embeddings = embeddings[time_stamp:time_stamp+10,:]
+
         l = embeddings.shape[0]
         if(l<10):
             while(l<10):

--- a/core/backend.py
+++ b/core/backend.py
@@ -98,6 +98,8 @@ class ModelWrapper(object):
         """
         if 0 < time_stamp < embeddings.shape[0]:
             embeddings = embeddings[time_stamp:time_stamp+10,:]
+        elif time_stamp < 0 or time_stamp >= embeddings.shape[0]:
+            raise ValueError('Invalid time stamp: value outside audio clip')
 
         l = embeddings.shape[0]
         if(l<10):


### PR DESCRIPTION
I have added an optional `start_time` argument to the predict call. This will have the model run prediction at the given start time rather than the start of the audio file.

This was inspired by the latest updates to my WIP web app based on this model https://github.com/ajbozarth/MAX-Audio-Classifier-Web-App

Implementation notes:

- The given time stamp (`start_time`) is converted to an relative embedding index by dividing by `vggish_params.EXAMPLE_HOP_SECONDS` (=`0.96`) and setting to `int`. This is to match an adjustment in the embedding process where one embedding = 0.96 seconds.
- If `start_time=0` then the if/elif statement is skipped and the original code is run as is
- If `start_time` is either negative or larger than the audio file length the a `ValueError` is thrown and the converted to a `BadRequest` to return to the user
- If `start_time` is within the final 10s of the file then it will loop the given section the same as if it was a <10s file
- `start_time` is a float in order to more easily support the value of HTML5 audio `currentTime` that I plan to use in my web app.
- Due to floating point arithmetic, negative values greater than `-0.96` will be accepted as valid since they'll round to 0 in the code, since the edge case detection is run after the time stamp is set to int it does not affect edge cases in the actual code and is only an oddity from a user's perspective